### PR TITLE
Fetch Agent logs when attack failed

### DIFF
--- a/src/ychaos/agents/agent.py
+++ b/src/ychaos/agents/agent.py
@@ -175,7 +175,7 @@ class Agent(ABC):
         Returns:
             None
         """
-        if self.current_state != AgentState.SETUP or not self.is_runnable():
+        if self.current_state != AgentState.SETUP:
             if self.config.raise_on_state_mismatch:
                 self.advance_state(AgentState.ABORTED)
                 raise AgentError("Agent state is not in SETUP state. Bailing out")
@@ -183,6 +183,9 @@ class Agent(ABC):
             warnings.warn(
                 "Agent is currently not in the SETUP state. Proceeding anyway"
             )
+
+        if not self.is_runnable():
+            raise AgentError("Agent not in executable state. Bailing out")
         self.advance_state(AgentState.RUNNING)
 
     def start(

--- a/src/ychaos/agents/coordinator.py
+++ b/src/ychaos/agents/coordinator.py
@@ -2,7 +2,6 @@
 #  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
 
 import os
-import traceback
 from datetime import datetime, timedelta, timezone
 from logging import Logger
 from queue import Queue
@@ -280,9 +279,9 @@ class Coordinator(EventHook):
                 error = configured_agent.agent.exception.get()
                 temp_exception_queue.put(error)
                 self.log.error(
-                    f"Error occurred for the Agent={configured_agent.agent.config.name}: {error}"
+                    f"Error occurred for the Agent={configured_agent.agent.config.name}",
+                    exc_info=error,
                 )
-                traceback.print_exception(type(error), error, error.__traceback__)
             configured_agent.agent.exception = temp_exception_queue
 
     def get_all_exceptions(self) -> list:

--- a/src/ychaos/core/executor/MachineTargetExecutor.py
+++ b/src/ychaos/core/executor/MachineTargetExecutor.py
@@ -249,6 +249,7 @@ class MachineTargetExecutor(BaseExecutor):
                 ),
                 dict(
                     name="Run YChaos Agent",
+                    ignore_errors="yes",
                     action=dict(
                         module="shell",
                         cmd=(

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -84,3 +84,12 @@ class TestBaseAgent(TestCase):
         t.join()
 
         self.assertEqual(agent.current_state, AgentState.ERROR)
+
+    def test_agent_run_when_is_not_runnable_raises_error(self):
+        agent = MockAgent(self.mock_agent_config.copy())
+        agent.exception.put(Exception("Error"))
+
+        with self.assertRaises(AgentError):
+            agent.run()
+
+        self.assertEqual(agent.current_state, AgentState.ABORTED)


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

- Execute rest of ansible tasks even if "Run YChaos Agent" task fails and still mark the whole run as FAILED
- log error stack trace

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [x] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [x] Reviewed Source Code
- [x] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [x] Reviewed Source Code
- [x] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
