### PR TITLE
Add a separate parser to run YChaos subcommands

### DIFF
--- a/src/ychaos/cli/agent/main.py
+++ b/src/ychaos/cli/agent/main.py
@@ -24,8 +24,9 @@ class Agent(YChaosSubCommand):
         test_plan_command_subparser = parser.add_subparsers(
             action=SubCommandParsersAction, dest=f"_cmd.{cls.name}"
         )
+        assert isinstance(test_plan_command_subparser, SubCommandParsersAction)
 
-        test_plan_command_subparser.add_parser(name=Attack.name, cls=Attack)
+        test_plan_command_subparser.add_parser(cls=Attack)
         return parser
 
     @classmethod

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -1,0 +1,37 @@
+#  Copyright 2021, Yahoo
+#  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
+from argparse import Namespace
+from typing import Any
+from unittest import TestCase
+
+from ychaos.cli import YChaosArgumentParser, YChaosCLIError
+from ychaos.utils.argparse import SubCommand
+
+
+class MockYChaosCLIError(YChaosCLIError):
+
+    exitcode = 2
+
+    def handle(self) -> None:
+        assert True is not False
+
+
+class MockSubCommand(SubCommand):
+
+    __err__ = {
+        0: None,
+        1: MockYChaosCLIError(app=None, message="CLI Error occurred"),
+        2: Exception("Unknown error"),
+    }
+
+    @classmethod
+    def main(cls, args: Namespace) -> Any:
+        if args.err != 0:
+            raise cls.__err__[args.err]
+
+
+class TestYChaosArgumentParser(TestCase):
+    def test_ychaos_argument_parser_handle_cli_error(self):
+        ychaos_arg_parser = YChaosArgumentParser()
+        exitcode = ychaos_arg_parser.run_command(Namespace(err=1, cls=MockSubCommand))
+        self.assertEqual(exitcode, 2)


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

This pull request is a work in development.

---

**Fixes**: #{issue_number}

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [x] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
