### PR TITLE
 Remove the requirement of virtualenv package on remote by using venv

### DIFF
--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -5,7 +5,7 @@ This section of the document contains the steps to get started with YChaos.
     pip install ychaos[chaos]
     ``` 
 1. Create a valid test plan. (Refer Ychaos test plan [schema](/ychaos/testplan/))
-1. Ensure the target hosts selected for testing have python3.6+, pip3 and virtualenv package pre-installed
+1. Ensure the target hosts selected for testing have python3.6+ and pip3 package pre-installed
 1. Execute the test plan 
     ```bash
     ychaos execute -t ./testplan.json

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,4 +68,4 @@ You can install the package using pip or directly from Github
     cd ychaos
     python setup.py develop easy_install ychaos[<subpackage>]
     ```
-Ychaos tool can be used with python3.6+ and must have pip3 and virtualenv pre-installed
+Ychaos tool can be used with python3.6+ and must have pip3 pre-installed

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -7,6 +7,8 @@
 1. Fix throwing error when a verification plugin implementation is not found or in development stage
 by [Shashank Sharma](https://github.com/shashankrnr32)
 
+1. Remove the requirement of virtualenv package on remote host by using venv by [Alfin S Thomas](https://github.com/AlfinST)
+
 ## Version 0.1.0
 
 1. Add documentation to YChaos by [Shashank Sharma](https://github.com/shashankrnr32)
@@ -46,4 +48,4 @@ code (CLI) by [Shashank Sharma](https://github.com/shashankrnr32)
    - Add Optional dependency handler by [Shashank Sharma](https://github.com/shashankrnr32)
    - Add Logging module for YChaos by [Vijay Babu](https://github.com/vijaybabu4589)
    - Add Log Agent Lifecycle decorator by [Shashank Sharma](https://github.com/shashankrnr32)
-   - Allow custom log file via CLI by Shashank Sharma
+   - Allow custom log file via CLI by [Shashank Sharma](https://github.com/shashankrnr32)

--- a/src/ychaos/core/executor/MachineTargetExecutor.py
+++ b/src/ychaos/core/executor/MachineTargetExecutor.py
@@ -215,20 +215,38 @@ class MachineTargetExecutor(BaseExecutor):
                     ],
                 ),
                 dict(
-                    name="Create a virtual environment and install ychaos[agents]",
+                    name="Create a virtual environment",
                     register="result_pip",
+                    action=dict(
+                        module="pip",
+                        chdir="{{result_pwd.stdout}}",
+                        name="pip",
+                        state="latest",
+                        virtualenv="ychaos_env",
+                        virtualenv_command="{{result_which_python3.stdout}} -m venv",
+                    ),
+                    failed_when=[
+                        # Failed in these following reasons
+                        # 1. pip not installed
+                        # 2. Failed to installed latest pip version
+                        "result_pip.state == 'absent'"
+                    ],
+                    vars=dict(
+                        ansible_python_interpreter="{{result_which_python3.stdout}}"
+                    ),
+                ),
+                dict(
+                    name="Install ychaos[agents]",
+                    register="result_pip_install_ychaos_agents",
                     action=dict(
                         module="pip",
                         chdir="{{result_pwd.stdout}}",
                         name="ychaos[agents]",
                         virtualenv="ychaos_env",
-                        virtualenv_python="python3",
                     ),
                     failed_when=[
-                        # Failed in these following reasons
-                        # 1. pip not installed
-                        # 2. Unable to install required packages
-                        "result_pip.state == 'absent'"
+                        # Failed if unable to install ychaos[agents]
+                        "result_pip_install_ychaos_agents.state == 'absent'"
                     ],
                     vars=dict(
                         ansible_python_interpreter="{{result_which_python3.stdout}}"


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

Currently, ychaos requires `virtualenv` package to be installed on the target hosts.
With these changes, we should be able to remove that requirement by using `venv` which comes with python3

---

**Fixes**: #7 

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
