### PR TITLE
Adding disk fill agent

### DIFF
--- a/src/ychaos/agents/index.py
+++ b/src/ychaos/agents/index.py
@@ -19,6 +19,7 @@ from .special.NoOpAgent import (
     NoOpTimedAgentConfig,
 )
 from .system.cpu import CPUBurn, CPUBurnConfig
+from .system.disk import DiskFill, DiskFillConfig
 from .system.icmp import PingDisable, PingDisableConfig
 from .validation.certificate import (
     CertificateFileValidation,
@@ -66,3 +67,5 @@ class AgentType(AEnum):
     DISABLE_PING = "disable_ping", SimpleNamespace(
         schema=PingDisableConfig, agent_defn=PingDisable
     )
+
+    DISK_FILL = "disk_fill", SimpleNamespace(schema=DiskFillConfig, agent_defn=DiskFill)

--- a/src/ychaos/agents/system/disk.py
+++ b/src/ychaos/agents/system/disk.py
@@ -1,0 +1,126 @@
+#  Copyright 2021, Yahoo
+#  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
+import math
+import shutil
+from pathlib import Path
+from queue import LifoQueue
+
+from pydantic import Field
+
+from ..agent import (
+    Agent,
+    AgentMonitoringDataPoint,
+    AgentPriority,
+    TimedAgentConfig,
+)
+from ..utils.annotations import log_agent_lifecycle
+
+
+class DiskFillConfig(TimedAgentConfig):
+    """
+    Defines the Disk Fill configuration to consume the disk space. The framework will
+    fill the disk space of a directory defined in `partition` and fill only a percentage of available
+    space, as defined in the `partition_pct` attribute. By default,
+    `partition_pct` is set to 100, implying the complete disk space of that partition will be filled.
+    """
+
+    name = "disk_fill"
+    description = "This agent fills up disk space."
+
+    priority = AgentPriority.MODERATE_PRIORITY
+
+    partition: Path = Field(
+        description="The Filepath of directory or partition to fill",
+        default=Path("/etc/"),
+        examples=["/etc/tmp", "/home/tmpuser"],
+    )
+
+    partition_pct: float = Field(
+        default=80,
+        description=(
+            "Percentage of the disk partition to fill"
+            "This will fill a percentage of the disk space on the partition"
+        ),
+        gt=0,
+        le=100,
+    )
+
+    max_file_size: int = Field(
+        default=(1024 * 1024 * 1024 * 20),  # Max file size is 20GB,
+        description=(
+            "Maximum size of each disk fill file. If the size to be filled exceeds this max file size, multiple"
+            "disk fill files will be used"
+        ),
+        gt=1024,
+    )
+
+    disk_fill_dir: str = Field(
+        default="ychaos_diskfill",
+        description=(
+            "Name of the temporary directory in which to store the disk fill files."
+            "This will be the path relative to the partition to fill"
+        ),
+    )
+
+    def effective_disk_to_fill(self) -> int:
+        """
+        Calculates the disk space that needs to be filled based on the available space in the partition and
+        the percentage of partition to fill partition_pct.
+        Returns:
+            disk space to fill in given partition.
+        """
+        stat = shutil.disk_usage(self.partition)
+        partition_size_available = stat.free
+        return math.floor(self.partition_pct / 100 * partition_size_available)
+
+
+class DiskFill(Agent):
+    def monitor(self) -> LifoQueue:
+        super(DiskFill, self).monitor()
+        available_space = shutil.disk_usage(self.config.partition).free
+
+        self._status.put(
+            AgentMonitoringDataPoint(
+                data=dict(
+                    disk_space_to_fill=self.config.effective_disk_to_fill(),
+                    disk_free_space=available_space,
+                ),
+                state=self.current_state,
+            )
+        )
+        return self._status
+
+    @log_agent_lifecycle
+    def setup(self) -> None:
+        super(DiskFill, self).setup()
+
+    @log_agent_lifecycle
+    def run(self) -> None:
+        super(DiskFill, self).run()
+        size = self.config.effective_disk_to_fill()
+        if size <= 0:
+            return
+        disk_fill_dir = Path(self.config.partition / self.config.disk_fill_dir)
+        disk_fill_dir.mkdir(parents=True, exist_ok=True)
+
+        space_remaining = size
+        index = 0
+        while space_remaining > 0:
+            if self.stop_async_run:
+                break
+            tmp = space_remaining
+            cur_file_size = self.config.max_file_size
+            space_remaining -= self.config.max_file_size
+            if space_remaining <= 0:
+                cur_file_size = tmp
+            with open(disk_fill_dir / f"filler{index}.txt", "wb") as f:
+                f.seek(cur_file_size - 1)
+                f.write(b"\0")
+            index += 1
+
+    @log_agent_lifecycle
+    def teardown(self) -> None:
+        super(DiskFill, self).teardown()
+        tmp_dir = self.config.partition / self.config.disk_fill_dir
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)

--- a/src/ychaos/testplan/resources/schema.json
+++ b/src/ychaos/testplan/resources/schema.json
@@ -132,7 +132,8 @@
                 "server_cert_validation",
                 "cert_file_validation",
                 "contrib",
-                "disable_ping"
+                "disable_ping",
+                "disk_fill"
             ]
         },
         "AgentExecutionConfig": {

--- a/tests/agents/system/test_disk.py
+++ b/tests/agents/system/test_disk.py
@@ -1,0 +1,153 @@
+#  Copyright 2021, Yahoo
+#  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
+import collections
+import shutil
+from pathlib import Path
+from unittest import TestCase
+
+from mockito import unstub, when
+
+from ychaos.agents.agent import AgentState
+from ychaos.agents.system.disk import DiskFill, DiskFillConfig
+
+
+class TestDiskFill(TestCase):
+    def setUp(self) -> None:
+        self.usage = collections.namedtuple("usage", "total used free")
+        self.stats = self.usage(2048, 1024, 1024)
+        when(shutil).disk_usage(Path(".")).thenReturn(self.stats)
+        self.disk_fill_config_50 = DiskFillConfig(
+            duration=0.1, partition="./", partition_pct=50
+        )
+        self.disk_fill_config_100 = DiskFillConfig(
+            duration=0.1, partition="./", partition_pct=100
+        )
+
+    def test_disk_fill_when_percentage_fill_normal(self):
+
+        disk_fill_agent = DiskFill(self.disk_fill_config_50)
+
+        self.assertEqual(
+            str(Path().resolve()),
+            self.disk_fill_config_50.partition.absolute().as_posix(),
+        )
+        self.assertEqual(50, self.disk_fill_config_50.partition_pct)
+
+        disk_fill_agent.setup()
+        self.assertEqual(AgentState.SETUP, disk_fill_agent.current_state)
+
+        disk_fill_agent.run()
+        self.assertEqual(AgentState.RUNNING, disk_fill_agent.current_state)
+
+        ychaos_diskfill_dir_path = Path().resolve() / "ychaos_diskfill"
+        self.assertTrue(ychaos_diskfill_dir_path.exists())
+        disk_dir = Path().resolve() / "ychaos_diskfill/filler0.txt"
+        self.assertEqual(512, disk_dir.stat().st_size)
+
+        disk_fill_agent.teardown()
+        self.assertEqual(AgentState.TEARDOWN, disk_fill_agent.current_state)
+        self.assertFalse(ychaos_diskfill_dir_path.exists())
+
+    def test_disk_fill_when_percentage_fill_full(self):
+        disk_fill_agent = DiskFill(self.disk_fill_config_100)
+
+        self.assertEqual(
+            str(Path().resolve()),
+            self.disk_fill_config_100.partition.absolute().as_posix(),
+        )
+        self.assertEqual(100, self.disk_fill_config_100.partition_pct)
+
+        disk_fill_agent.setup()
+        self.assertEqual(AgentState.SETUP, disk_fill_agent.current_state)
+
+        disk_fill_agent.run()
+        self.assertEqual(AgentState.RUNNING, disk_fill_agent.current_state)
+
+        disk_dir = Path().resolve() / "ychaos_diskfill/filler0.txt"
+        self.assertEqual(1024, disk_dir.stat().st_size)
+
+        disk_fill_agent.teardown()
+        self.assertEqual(AgentState.TEARDOWN, disk_fill_agent.current_state)
+
+    def test_disk_fill_when_percentage_fill_stop_run(self):
+        disk_fill_agent = DiskFill(self.disk_fill_config_100)
+
+        self.assertEqual(
+            str(Path().resolve()),
+            self.disk_fill_config_100.partition.absolute().as_posix(),
+        )
+        self.assertEqual(100, self.disk_fill_config_100.partition_pct)
+
+        disk_fill_agent.setup()
+        self.assertEqual(AgentState.SETUP, disk_fill_agent.current_state)
+
+        disk_fill_agent.stop_async_run = True
+
+        disk_fill_agent.run()
+        self.assertEqual(AgentState.RUNNING, disk_fill_agent.current_state)
+
+        ychaos_diskfill_file_0 = Path().resolve() / "ychaos_diskfill/filler0.txt"
+        self.assertFalse(ychaos_diskfill_file_0.exists())
+
+        disk_fill_agent.teardown()
+        self.assertEqual(AgentState.TEARDOWN, disk_fill_agent.current_state)
+
+    def test_disk_teardown_with_multiple_files(self):
+        self.disk_fill_config_100.max_file_size = 1000
+        disk_fill_agent = DiskFill(self.disk_fill_config_100)
+
+        self.assertEqual(
+            str(Path().resolve()),
+            self.disk_fill_config_100.partition.absolute().as_posix(),
+        )
+        self.assertEqual(100, self.disk_fill_config_100.partition_pct)
+
+        disk_fill_agent.setup()
+        self.assertEqual(AgentState.SETUP, disk_fill_agent.current_state)
+
+        disk_fill_agent.run()
+        self.assertEqual(AgentState.RUNNING, disk_fill_agent.current_state)
+
+        disk_dir = Path().resolve() / "ychaos_diskfill/filler0.txt"
+        self.assertEqual(1000, disk_dir.stat().st_size)
+
+        disk_fill_agent.teardown()
+        self.assertEqual(AgentState.TEARDOWN, disk_fill_agent.current_state)
+
+    def test_disk_teardown_without_disk_fill_dir(self):
+        stats = self.usage(4096, 4096, 0)
+        when(shutil).disk_usage(Path(".")).thenReturn(stats)
+        disk_fill_agent = DiskFill(self.disk_fill_config_100)
+
+        self.assertEqual(
+            str(Path().resolve()),
+            self.disk_fill_config_100.partition.absolute().as_posix(),
+        )
+        self.assertEqual(100, self.disk_fill_config_100.partition_pct)
+
+        disk_fill_agent.setup()
+        self.assertEqual(AgentState.SETUP, disk_fill_agent.current_state)
+
+        disk_fill_agent.run()
+        self.assertEqual(AgentState.RUNNING, disk_fill_agent.current_state)
+
+        files_dir = Path().resolve() / "ychaos_diskfill"
+        self.assertFalse(files_dir.exists())
+
+        disk_fill_agent.teardown()
+        self.assertEqual(AgentState.TEARDOWN, disk_fill_agent.current_state)
+
+    def test_disk_burn_monitor(self):
+        disk_fill_config = DiskFillConfig(
+            duration=0.1, partition="./", partition_pct=50
+        )
+        disk_fill_agent = DiskFill(disk_fill_config)
+
+        monitor_status_queue = disk_fill_agent.monitor()
+        status = monitor_status_queue.get()
+
+        self.assertEqual(512, status.data["disk_space_to_fill"])
+        self.assertEqual(1024, status.data["disk_free_space"])
+
+    def tearDown(self) -> None:
+        unstub()


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev 

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

This is to add the agent for disk fill - fill disk space based on partition given and percentage of the disk that needs to be filled. We do this by added junk files in the partition. 

---

**Fixes**: https://github.com/yahoo/ychaos/issues/13

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [x] Security warnings ignored (Why?!)

#### Project related
- [x] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [x] Auto generated schema

### Pre-Merge Checklist

- [x] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
