### PR TITLE
Add new hook `on_plugin_not_found` for Verification Controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,15 @@ autogen:
 	ychaos manual --file docs/cli/manual.md > /dev/null
 
 # Builds documentation and serves on http://localhost:8000
-.PHONEY: doc
+.PHONY: doc
 doc:
 	chmod +x develop/doc.sh
 	./develop/doc.sh
 
-.PHONEY: docbuild
+.PHONY: docbuild
 docbuild:
 	mkdocs build
+
+.PHONY: schema
+schema:
+	python3 develop/autogen_schema.py

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,7 +2,12 @@
 
 ## Version 0.x.x
 
-## Next release (Version 0.1.0)
+## Next Release (0.2.0)
+
+1. Fix throwing error when a verification plugin implementation is not found or in development stage
+by [Shashank Sharma](https://github.com/shashankrnr32)
+
+## Version 0.1.0
 
 1. Add documentation to YChaos by [Shashank Sharma](https://github.com/shashankrnr32)
    

--- a/src/ychaos/cli/verify.py
+++ b/src/ychaos/cli/verify.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 from ..core.verification.controller import VerificationController
 from ..core.verification.data import VerificationStateData
 from ..testplan import SystemState
-from ..testplan.verification import VerificationConfig
+from ..testplan.verification import VerificationConfig, VerificationType
 from . import YChaosCLIHook, YChaosTestplanInputSubCommand
 
 __all__ = ["Verify"]
@@ -125,6 +125,12 @@ class Verify(YChaosTestplanInputSubCommand):
                     f"Running [i]{self.state.value.lower()}[/i] state verification of type={config.type.value}[{index}]"
                 )
 
+        class OnPluginNotFoundHook(VerificationHook):
+            def __call__(self, index: int, plugin_type: VerificationType):
+                self.console.log(
+                    f"The verification plugin type=[i]{plugin_type.value}[/i][{index}] is not available for use."
+                )
+
         class OnEachPluginEndHook(VerificationHook):
             def __call__(
                 self,
@@ -149,6 +155,9 @@ class Verify(YChaosTestplanInputSubCommand):
         )
         verification_controller.register_hook(
             "on_each_plugin_end", OnEachPluginEndHook(self.app, self.state)
+        )
+        verification_controller.register_hook(
+            "on_plugin_not_found", OnPluginNotFoundHook(self.app, self.state)
         )
 
         self.console.log(

--- a/src/ychaos/testplan/resources/schema.json
+++ b/src/ychaos/testplan/resources/schema.json
@@ -46,7 +46,8 @@
             "enum": [
                 "python_module",
                 "http_request",
-                "sdv4"
+                "sdv4",
+                "noop"
             ]
         },
         "VerificationConfig": {

--- a/src/ychaos/testplan/verification.py
+++ b/src/ychaos/testplan/verification.py
@@ -141,6 +141,10 @@ class SDv4Verification(SchemaModel):
     job_timeout: PositiveInt = Field(default=3600, description="Job Timeout in seconds")
 
 
+class NoOpConfig(SchemaModel):
+    pass
+
+
 class VerificationType(AEnum):
     """
     Defines the Type of plugin to be used for verification.
@@ -152,6 +156,9 @@ class VerificationType(AEnum):
     PYTHON_MODULE = "python_module", SimpleNamespace(schema=PythonModuleVerification)
     HTTP_REQUEST = "http_request", SimpleNamespace(schema=HTTPRequestVerification)
     SDV4_VERIFICATION = "sdv4", SimpleNamespace(schema=SDv4Verification)
+
+    # For Testing purpose, cannot be used by users.
+    NOOP = "noop", SimpleNamespace(schema=NoOpConfig)
 
 
 class VerificationConfig(SchemaModel):

--- a/tests/cli/test_verify.py
+++ b/tests/cli/test_verify.py
@@ -189,3 +189,24 @@ class TestVerificationCommand(TestCase):
         self.assertTrue(
             "The system is verified to be in steady state" in app.get_console_output()
         )
+
+    def test_verification_for_valid_testplan_with_unimplemented_plugin(self):
+        args = Namespace()
+        args.cls = self.cls
+
+        testplan_path = self.testplans_directory.joinpath("valid/testplan6.yaml")
+
+        # Required Arguments for VerificationCommand
+        args.testplan = str(testplan_path.resolve())
+        args.state = "steady"
+
+        # Create a Mocked CLI App
+        app = MockApp(args)
+        args.app = app
+
+        self.assertEqual(0, args.cls.main(args))
+
+        self.assertTrue(
+            "The verification plugin type=noop[0] is not available for use."
+            in app.get_console_output()
+        )

--- a/tests/resources/testplans/valid/testplan6.yaml
+++ b/tests/resources/testplans/valid/testplan6.yaml
@@ -1,0 +1,11 @@
+description: A valid mock testplan file with un-implemented verification plugin
+verification:
+    - states:
+          - CHAOS
+          - STEADY
+      type: noop
+      config: {}
+attack:
+    target_type: self
+    agents:
+        - type: no_op


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

1. If the plugin is not implemented yet, the Verification controller raises error.
2. This PR introduces a new hook for Verification controller to handle if there is a plugin in schema but no handler for it.

## YChaos CLI update
| Before this Change | After this change |
| ---- | ---- |
| ![Screenshot 2021-07-28 at 11 06 51 PM](https://user-images.githubusercontent.com/29425899/127370613-381be6a9-f881-4a4e-a0a3-b838356636d6.png) | ![Screenshot 2021-07-28 at 11 12 33 PM](https://user-images.githubusercontent.com/29425899/127370763-da324849-b2ca-4a72-93ca-6fddcc5dcecd.png) |
| CLI Exits with 255 | CLI exits with 0 by printing "Plugin is not available for use" |




---

**Fixes**: #{issue_number}

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [x] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [x] Auto generated schema

### Pre-Merge Checklist

- [x] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
