### PR TITLE
Fix returncode for no-op commands

### DIFF
--- a/src/ychaos/cli/__init__.py
+++ b/src/ychaos/cli/__init__.py
@@ -3,7 +3,7 @@
 from abc import ABC
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import ValidationError
 from rich.console import Console
@@ -68,6 +68,11 @@ class YChaosSubCommand(SubCommand, ABC):
 
     def set_exitcode(self, exitcode=0):
         self._exitcode = exitcode
+
+    @classmethod
+    def main(cls, args: Namespace) -> Any:
+        args.app.console.log("This command does nothing..")
+        return 0
 
 
 class YChaosTestplanInputSubCommand(YChaosSubCommand, ABC):

--- a/src/ychaos/cli/agent/main.py
+++ b/src/ychaos/cli/agent/main.py
@@ -1,7 +1,7 @@
 #  Copyright 2021, Yahoo
 #  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
 
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 
 from ...utils.argparse import SubCommandParsersAction
 from .. import YChaosSubCommand
@@ -28,7 +28,3 @@ class Agent(YChaosSubCommand):
 
         test_plan_command_subparser.add_parser(cls=Attack)
         return parser
-
-    @classmethod
-    def main(cls, args: Namespace):
-        pass

--- a/src/ychaos/cli/testplan/main.py
+++ b/src/ychaos/cli/testplan/main.py
@@ -1,8 +1,7 @@
 #  Copyright 2021, Yahoo
 #  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
 
-from argparse import ArgumentParser, Namespace
-from typing import Any
+from argparse import ArgumentParser
 
 from ...utils.argparse import SubCommandParsersAction
 from .. import YChaosSubCommand
@@ -31,7 +30,3 @@ class TestPlan(YChaosSubCommand):
         )
 
         return parser
-
-    @classmethod
-    def main(cls, args: Namespace) -> Any:  # pragma: no cover
-        pass


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev 

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

Fix returncode for no-op commands. Previously returning `None`. After this change, returns 0 and exits gracefully. This is for ychaos cli commands that are either not used or not implemented.

---

**Fixes**: #{issue_number}

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
