### PR TITLE
Adding openSSL as common dependency

### DIFF
--- a/develop/build.sh
+++ b/develop/build.sh
@@ -34,7 +34,7 @@ function flake8_validation() {
 function codespell_validation() {
     echo "==============================================="
     echo "Running codespell validation"
-    codespell src tests develop docs || { echo "codespell Validation Failed" ; exit 1; }
+    codespell src tests develop docs --skip "*.css" || { echo "codespell Validation Failed" ; exit 1; }
     echo "codespell validation passing"
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     pyyaml==5.4.1
     requests==2.26.0
     rich==10.9.0
+    pyOpenSSL==20.0.1
 
 # By default new packages require at minimum the current supported Python release.
 python_requires = >="3.6"
@@ -58,7 +59,6 @@ chaos =
 
 agents =
     psutil==5.8.0
-    pyOpenSSL==20.0.1
 
 # Additional packages for testing (test step)
 test =
@@ -73,7 +73,6 @@ test =
 
     #agents
     psutil==5.8.0
-    pyOpenSSL==20.0.1
 
     pytest-timeout
     parameterized
@@ -92,7 +91,6 @@ doc_build =
 
     #agents
     psutil==5.8.0
-    pyOpenSSL==20.0.1
 
     # https://github.com/mkdocstrings/mkdocstrings/issues/295
     livereload
@@ -158,7 +156,6 @@ debug =
 
     # agents
     psutil==5.8.0
-    pyOpenSSL==20.0.1
 
 
 [options.entry_points]


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

index.py under Agent module is imported in ychaos CLI, index.py imports certificate validation modules and openSSL is one of main dependency of certificate validation modules.

## Checklist

### Checklist (Developer)

#### Prerequisites
- [ ] I have read the contribution guidelines

#### Code Analysis
- [ ] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
