### PR TITLE
Fix importing not-needed PyOpenSSL dependency

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,9 @@
 
 1. Add Disk Fill Agent by [Lakshmi Kannan](https://github.com/lakshmi-k05)
 
+2. Fix importing non-required PyOpenSSL module by [Shashank Sharma](https://github.com/shashankrnr32)
+and [Vijay Babu](https://github.com/vijaybabu4589)
+
 ### Version 0.2.0
 
 1. Fix throwing error when a verification plugin implementation is not found or in development stage

--- a/src/ychaos/agents/validation/certificate.py
+++ b/src/ychaos/agents/validation/certificate.py
@@ -133,8 +133,8 @@ class CertificateFileType(AEnum):
             return pyopenssl.OpenSSL.crypto.FILETYPE_PEM
         elif self == self.ASN1:
             return pyopenssl.OpenSSL.crypto.FILETYPE_ASN1
-        else:
-            raise Exception()
+        else:  # pragma: no cover
+            raise Exception("Unknown Certificate FileType")
 
 
 class CertificateFileConfig(BaseModel):

--- a/src/ychaos/agents/validation/certificate.py
+++ b/src/ychaos/agents/validation/certificate.py
@@ -23,11 +23,12 @@ from ..agent import Agent, AgentConfig, AgentMonitoringDataPoint, AgentPriority
 from ..utils.annotations import log_agent_lifecycle
 
 (X509,) = DependencyUtils.import_from(
-    "OpenSSL.crypto",
-    ("X509",),
+    "OpenSSL.crypto", ("X509",), raise_error=False, warn=False
 )
 
-pyopenssl = DependencyUtils.import_module("requests.packages.urllib3.contrib.pyopenssl")
+pyopenssl = DependencyUtils.import_module(
+    "requests.packages.urllib3.contrib.pyopenssl", raise_error=False, warn=False
+)
 
 
 class ServerCertValidationConfig(AgentConfig):
@@ -121,8 +122,19 @@ class CertificateFileType(AEnum):
         PEM: (pem) PEM Certificate format
     """
 
-    ASN1 = "asn1", SimpleNamespace(binder=pyopenssl.OpenSSL.crypto.FILETYPE_ASN1)  # type: ignore
-    PEM = "pem", SimpleNamespace(binder=pyopenssl.OpenSSL.crypto.FILETYPE_PEM)  # type: ignore
+    ASN1 = "asn1", SimpleNamespace()
+    PEM = "pem", SimpleNamespace()
+
+    def binder(self):
+        pyopenssl = DependencyUtils.import_module(
+            "requests.packages.urllib3.contrib.pyopenssl", raise_error=False
+        )
+        if self == self.PEM:
+            return pyopenssl.OpenSSL.crypto.FILETYPE_PEM
+        elif self == self.ASN1:
+            return pyopenssl.OpenSSL.crypto.FILETYPE_ASN1
+        else:
+            raise Exception()
 
 
 class CertificateFileConfig(BaseModel):
@@ -175,7 +187,7 @@ class CertificateFileValidation(Agent):
             try:
                 assert pyopenssl is not None
                 cert = pyopenssl.OpenSSL.crypto.load_certificate(
-                    cert_path_config.type.metadata.binder,
+                    cert_path_config.type.binder(),
                     cert_path_config.path.read_bytes(),
                 )
 

--- a/src/ychaos/utils/dependency.py
+++ b/src/ychaos/utils/dependency.py
@@ -16,7 +16,7 @@ class DependencyUtils:
 
     @classmethod
     def import_module(
-        cls, name: str, message: str = None, raise_error: bool = True
+        cls, name: str, message: str = None, raise_error: bool = True, warn: bool = True
     ) -> Optional[Any]:
         """
         Calling this method with a module name is similar to calling
@@ -26,6 +26,7 @@ class DependencyUtils:
             name: Module name
             message: Error message to be printed on console when the import fails
             raise_error: Raise an error if the import fails
+            warn: Raise warning if the import fails
 
         Raises:
             ImportError: when `raise_error` is True and the module is not present
@@ -39,7 +40,9 @@ class DependencyUtils:
             if not message:
                 message = f"Dependency {name} is not installed."
 
-            warnings.warn(message)
+            if warn:
+                warnings.warn(message)
+
             if raise_error:
                 raise ImportError(message) from None
             else:
@@ -55,6 +58,7 @@ class DependencyUtils:
         attrs: Tuple[str, ...],
         message: str = None,
         raise_error: bool = True,
+        warn: bool = True,
     ) -> Tuple[Any, ...]:
         """
         Calling this method with a module and an attribute is similar to calling
@@ -77,6 +81,7 @@ class DependencyUtils:
             attrs: Tuple of attribute names from the module
             message: message to be printed in case of an error
             raise_error: Raise an error if the import fails
+            warn: Throw a warning if the import fails
 
         Raises:
             ImportError: when `raise_error` is true and `attr_name` cannot be imported from the `module_name`
@@ -85,7 +90,7 @@ class DependencyUtils:
             An attribute from module_name if exists, None otherwise
         """
         module = cls.import_module(
-            name=module_name, message=message, raise_error=raise_error
+            name=module_name, message=message, raise_error=raise_error, warn=warn
         )
 
         if not module:
@@ -99,7 +104,9 @@ class DependencyUtils:
                 except AttributeError as attr_error:
                     if not message:
                         message = f"cannot import {_attr_name} from {module_name}"
-                    warnings.warn(message)
+
+                    if warn:
+                        warnings.warn(message)
                     if raise_error:
                         raise ImportError(message) from None
                     else:

--- a/tests/agents/validation/test_CertificateFileValidation.py
+++ b/tests/agents/validation/test_CertificateFileValidation.py
@@ -4,10 +4,23 @@ from datetime import datetime, timedelta, timezone
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
+from urllib3.contrib import pyopenssl
+
 from ychaos.agents.validation.certificate import (
+    CertificateFileType,
     CertificateFileValidation,
     CertificateFileValidationConfig,
 )
+
+
+class TestCertificateFileType(TestCase):
+    def test_binder(self):
+        self.assertEqual(
+            CertificateFileType.PEM.binder(), pyopenssl.OpenSSL.crypto.FILETYPE_PEM
+        )
+        self.assertEqual(
+            CertificateFileType.ASN1.binder(), pyopenssl.OpenSSL.crypto.FILETYPE_ASN1
+        )
 
 
 class TestCertificateFileValidation(TestCase):

--- a/tests/utils/test_dependency.py
+++ b/tests/utils/test_dependency.py
@@ -56,6 +56,7 @@ class TestDependencyUtils(TestCase):
                 "ychaos.utils.dependency",
                 ("SomeUnknownAttribute",),
                 raise_error=True,
+                warn=False,
             )
 
     def test_import_attr_from_invalid_module(self):
@@ -63,5 +64,6 @@ class TestDependencyUtils(TestCase):
             "ychaos.some_unknown_module",
             ("SomeUnknownAttribute",),
             raise_error=False,
+            warn=False,
         )
         self.assertTupleEqual((None,), handler_class)


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

Fix importing not-needed PyOpenSSL dependency

---

**Fixes**: #{issue_number}

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
