### PR TITLE
Handle dump yaml/json File not found error

### DIFF
--- a/src/ychaos/core/verification/controller.py
+++ b/src/ychaos/core/verification/controller.py
@@ -203,6 +203,12 @@ class VerificationController(EventHook):
     def get_encoded_verification_data(self):
         return [data.encoded_dict() for data in self.verification_data]
 
+    def dump_verification(self, fp, output_format):
+        if output_format == "json":
+            self.dump_verification_json(fp)
+        else:
+            self.dump_verification_yaml(fp)
+
     def dump_verification_json(self, fp):
         import json
 


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

Gracefully creating the dump path and error out if there are any permission errors both directory level/ or file level.

**Fixes**: #62

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [x] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [x] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
