### PR TITLE
Publish docker image with ychaos pre-installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:3.6-alpine
+RUN apk --update add --virtual build-dependencies libffi-dev gcc musl-dev &&  pip install ychaos[chaos]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -143,6 +143,17 @@ jobs:
         template: python/package_python
         requires: [version_test_pypi]
 
+    # publish latest ychaos version to docker hub
+    publish_test_docker:
+        secrets:
+            - DOCKER_REGISTRY_USER
+            - DOCKER_REGISTRY_TOKEN
+        environment:
+            DOCKER_REPO: ychaos/ychaos
+        template: sd/dind@latest
+        requires: [package_publish_test_pypi]
+
+
     # Release Pipeline to publish package to PyPi
     # This is manually triggered by the maintainers
     # to publish a new version release to PyPi


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

Temporarily push ychaos beta version to docker hub

---


<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [ ] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [x] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
