### PR TITLE
Add 'all' as the way to install both chaos and agents subpackage together

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 ARG PY_VERSION
 FROM python:${PY_VERSION}-alpine
-RUN apk --no-cache --update add --virtual build-dependencies libffi-dev gcc musl-dev && pip install ychaos[chaos]
+RUN apk --no-cache --update add --virtual build-dependencies libffi-dev gcc musl-dev && pip install ychaos[all]

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,19 +68,32 @@ You can install the package using pip or directly from Github
     cd ychaos
     python setup.py develop easy_install ychaos[<subpackage>]
     ```
-Ychaos tool can be used with python3.6+ and must have pip3 pre-installed
+
+If you are interested in installing all the above subpackages together,
+you can run
+
+```bash
+pip install ychaos[all]
+```
+
+YChaos tool can be used with python3.6+ and must have pip3 pre-installed
 
 ## Docker hub
 
-Python version specific YChaos images are published with each release of YChaos, at present Python `3.6`, `3.7`, `3.8`, `3.9` based images are available at [Docker hub](https://hub.docker.com/r/ychaos/ychaos).
+Python version specific YChaos images are published with each release of YChaos, at present Python `3.6`-`3.9` 
+based images are available on [Docker hub](https://hub.docker.com/r/ychaos/ychaos).
 
 === "Docker"
-    ```
+    ```bash
     docker pull ychaos/ychaos
     ```
+
     Above command will pull the latest Python 3.6 based YChaos image. 
     For any other Python version specific images use
-    ```
+
+    ```bash
     docker pull ychaos/ychaos:py<version>-latest
     ```
-    Refer [Docker tags](https://hub.docker.com/r/ychaos/ychaos/tags) for all the available Image tags
+
+    Refer [Docker tags](https://hub.docker.com/r/ychaos/ychaos/tags) 
+    for all the available Image tags

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,11 @@ agents =
     psutil==5.8.0
     pyOpenSSL==21.0.0
 
+all =
+    ansible==3.2.0
+    psutil==5.8.0
+    pyOpenSSL==21.0.0
+
 # Additional packages for testing (test step)
 test =
     mockito


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

This is a Pull Request that is capable of changing the world.

---

**Fixes**: #{issue_number}

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [ ] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
