### PR TITLE
Add support to SSH common args in TestPlan, make SSH config optional

### DIFF
--- a/src/ychaos/testplan/attack.py
+++ b/src/ychaos/testplan/attack.py
@@ -1,6 +1,7 @@
 #  Copyright 2021, Yahoo
 #  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
 import getpass
+import os
 import re
 from enum import Enum
 from pathlib import Path
@@ -35,6 +36,15 @@ class SSHConfig(SchemaModel):
         default=None,
         description="The password that will be used to login to the hosts.",
     )
+    ssh_common_args: str = Field(
+        default=os.getenv("ANSIBLE_SSH_COMMON_ARGS", ""),
+        description="The common Arguments to be used while SSHing to a host with Ansible (`$ANSIBLE_SSH_COMMON_ARGS`)",
+    )
+
+    @validator("ssh_common_args", always=True)
+    def set_ssh_common_args_env(cls, v):
+        os.environ["ANSIBLE_SSH_COMMON_ARGS"] = v
+        return v
 
 
 class MachineTargetDefinition(TargetDefinition):
@@ -65,7 +75,8 @@ class MachineTargetDefinition(TargetDefinition):
     )
 
     ssh_config: SSHConfig = Field(
-        ..., description="The configuration used to SSH to the target machines."
+        default=SSHConfig(),
+        description="The configuration used to SSH to the target machines.",
     )
 
     hostnames: List[FQDN] = Field(


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

<!-- 
    Provide a general summary of what changes are you proposing in this
    pull request. This may include the approaches taken to solve a problem
-->

1. Add Support to SSH Common args in testplan (Can also use ENV variable)
2. SSH config is optional, since all the parameters inside it have defaults 

---

**Fixes**: 

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
