### PR TITLE
Temporarily fix Type Validation

### DIFF
--- a/src/ychaos/core/executor/common.py
+++ b/src/ychaos/core/executor/common.py
@@ -1,6 +1,5 @@
 #  Copyright 2021, Yahoo
 #  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
-import collections
 from typing import Any
 
 from ...utils.dependency import DependencyUtils
@@ -22,10 +21,9 @@ if CallbackBase:  # pragma: no cover
         This is a callback plugin which help performing actions as results from running the ansible playbook comes in.
         """
 
-        __hook_events__ = collections.defaultdict(
-            EventHook.CallableType(TaskResult)
-        ).fromkeys(
-            (
+        __hook_events__ = dict(
+            (event, EventHook.CallableType(TaskResult))
+            for event in (
                 "on_target_unreachable",
                 "on_target_failed",
                 "on_target_passed",

--- a/src/ychaos/utils/builtins.py
+++ b/src/ychaos/utils/builtins.py
@@ -6,7 +6,7 @@ from enum import Enum, EnumMeta
 from types import DynamicClassAttribute, SimpleNamespace
 from typing import Any, Iterable, List, Optional, Type, TypeVar
 
-T = TypeVar("T")
+T = TypeVar("T", bound=Enum)
 
 
 class BuiltinUtils:
@@ -106,7 +106,7 @@ class AEnum(Enum, metaclass=EnumMeta):
     def __new__(cls: Type[T], value, metadata: Optional[SimpleNamespace] = None):
         obj = object.__new__(cls)
         obj._value_ = value
-        obj.metadata = metadata
+        obj.metadata = metadata  # type: ignore
 
         # Add Aliases to Serializer Dictionary
         for alias in getattr(metadata, "__aliases__", tuple()):


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

after mypy 0.920 was released on 16th Dec, the type validation pipeline was broken
This PR fixes it

---

## Checklist

### Checklist (Developer)

#### Prerequisites
- [ ] I have read the contribution guidelines

#### Code Analysis
- [ ] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
