### PR TITLE
fix range verification criteria

### DIFF
--- a/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
+++ b/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
@@ -75,7 +75,7 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
                 for _condition in _criteria.conditionals:
                     args = (_aggregated_data, _condition.value)
                     if _condition.comparator == MetricsComparator.RANGE:
-                        args = (_condition._comparator, *args)
+                        args = (_condition._comparator, *args)  # type: ignore
                     if _condition.comparator.metadata.compare(*args):  # type: ignore
                         break
                 else:

--- a/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
+++ b/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
@@ -12,12 +12,6 @@ from ..data import VerificationData, VerificationStateData
 from .BaseVerificationPlugin import RequestVerificationPlugin
 
 
-def resolve_comparator(condition) -> str:
-    if condition._comparator == "range":
-        return "[]"
-    return condition._comparator
-
-
 class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
     class OpenTSDBVerificationData(BaseModel):
         url: str  # Making this string since this is built with only trusted data
@@ -79,9 +73,9 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
                 )
 
                 for _condition in _criteria.conditionals:
-                    args = [_aggregated_data, _condition.value]
+                    args = (_aggregated_data, _condition.value)
                     if _condition.comparator == MetricsComparator.RANGE:
-                        args = [resolve_comparator(_condition), *args]
+                        args = (_condition._comparator, *args)
                     if _condition.comparator.metadata.compare(*args):  # type: ignore
                         break
                 else:

--- a/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
+++ b/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
@@ -64,10 +64,10 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
         )
 
     def validate_criteria(self, response_data: List[Dict[str, Any]]):
-        def __get_comparator_args(condition, aggregated_data, value) -> tuple:
+        def _get_comparator_args(condition, aggregated_data):
             if condition.comparator == MetricsComparator.RANGE:
-                return _condition._comparator, aggregated_data, value
-            return aggregated_data, value
+                return condition._comparator, aggregated_data, condition.value
+            return aggregated_data, condition.value
 
         for _query_data in response_data:
 
@@ -78,9 +78,7 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
                 )
 
                 for _condition in _criteria.conditionals:
-                    args = __get_comparator_args(
-                        _condition, _aggregated_data, _condition.value
-                    )
+                    args = _get_comparator_args(_condition, _aggregated_data)
                     if _condition.comparator.metadata.compare(*args):  # type: ignore
                         break
                 else:

--- a/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
+++ b/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
@@ -78,8 +78,9 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
                 )
 
                 for _condition in _criteria.conditionals:
-                    args = _get_comparator_args(_condition, _aggregated_data)
-                    if _condition.comparator.metadata.compare(*args):  # type: ignore
+                    if _condition.comparator.metadata.compare(
+                        *_get_comparator_args(_condition, _aggregated_data)
+                    ):
                         break
                 else:
                     return 1

--- a/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
+++ b/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
@@ -64,6 +64,11 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
         )
 
     def validate_criteria(self, response_data: List[Dict[str, Any]]):
+        def __get_comparator_args(condition, aggregated_data, value) -> tuple:
+            if condition.comparator == MetricsComparator.RANGE:
+                return _condition._comparator, aggregated_data, value
+            return aggregated_data, value
+
         for _query_data in response_data:
 
             for _criteria in self.config.criteria:
@@ -73,9 +78,9 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
                 )
 
                 for _condition in _criteria.conditionals:
-                    args = (_aggregated_data, _condition.value)
-                    if _condition.comparator == MetricsComparator.RANGE:
-                        args = (_condition._comparator, *args)  # type: ignore
+                    args = __get_comparator_args(
+                        _condition, _aggregated_data, _condition.value
+                    )
                     if _condition.comparator.metadata.compare(*args):  # type: ignore
                         break
                 else:

--- a/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
+++ b/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
@@ -8,7 +8,7 @@ from parameterized import parameterized
 from requests import Response
 
 from ychaos.core.verification.plugins.OpenTSDBVerificationPlugin import (
-    OpenTSDBVerificationPlugin
+    OpenTSDBVerificationPlugin,
 )
 from ychaos.testplan.verification import (
     MultipleConditionalsMetricsVerificationCriteria,

--- a/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
+++ b/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
@@ -8,8 +8,7 @@ from parameterized import parameterized
 from requests import Response
 
 from ychaos.core.verification.plugins.OpenTSDBVerificationPlugin import (
-    OpenTSDBVerificationPlugin,
-    resolve_comparator,
+    OpenTSDBVerificationPlugin
 )
 from ychaos.testplan.verification import (
     MultipleConditionalsMetricsVerificationCriteria,
@@ -178,17 +177,6 @@ class TestOpenTSDBVerificationPlugin(TestCase):
 
         state_data = verification_plugin.run_verification()
         self.assertEqual(state_data.rc, 0)
-
-    @parameterized.expand(
-        [
-            (ComparisonCondition(comparator="[]", value=(0, 10)), "[]"),
-            (ComparisonCondition(comparator="range", value=(0, 10)), "[]"),
-            (ComparisonCondition(comparator="[)", value=(0, 10)), "[)"),
-            (ComparisonCondition(comparator="()", value=(0, 10)), "()"),
-        ]
-    )
-    def test_resolve_comparator(self, condition, expected):
-        self.assertEqual(resolve_comparator(condition), expected)
 
     def tearDown(self) -> None:
         unstub()

--- a/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
+++ b/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
@@ -4,6 +4,7 @@ from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
 from mockito import mock, unstub, when
+from parameterized import parameterized
 from requests import Response
 
 from ychaos.core.verification.plugins.OpenTSDBVerificationPlugin import (
@@ -178,13 +179,16 @@ class TestOpenTSDBVerificationPlugin(TestCase):
         state_data = verification_plugin.run_verification()
         self.assertEqual(state_data.rc, 0)
 
-    def test_resolve_comparator(self):
-        condition = ComparisonCondition(comparator="==", value=25625991360)
-        self.assertEqual(resolve_comparator(condition), "==")
-        condition = ComparisonCondition(comparator="range", value=(0, 10))
-        self.assertEqual(resolve_comparator(condition), "[]")
-        condition = ComparisonCondition(comparator="[)", value=(0, 10))
-        self.assertEqual(resolve_comparator(condition), "[)")
+    @parameterized.expand(
+        [
+            (ComparisonCondition(comparator="[]", value=(0, 10)), "[]"),
+            (ComparisonCondition(comparator="range", value=(0, 10)), "[]"),
+            (ComparisonCondition(comparator="[)", value=(0, 10)), "[)"),
+            (ComparisonCondition(comparator="()", value=(0, 10)), "()"),
+        ]
+    )
+    def test_resolve_comparator(self, condition, expected):
+        self.assertEqual(resolve_comparator(condition), expected)
 
     def tearDown(self) -> None:
         unstub()

--- a/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
+++ b/tests/core/verification/plugins/test_OpenTSDBVerificationPlugin.py
@@ -4,7 +4,6 @@ from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
 from mockito import mock, unstub, when
-from parameterized import parameterized
 from requests import Response
 
 from ychaos.core.verification.plugins.OpenTSDBVerificationPlugin import (


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

The range criteria require range_type to be passed for comparison. This isn't passed currently.
This PR fixes it by passing it.

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
