### PR TITLE
fix ComparisonCondition after forbidding extra fields

### DIFF
--- a/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
+++ b/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
@@ -66,7 +66,7 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
     def validate_criteria(self, response_data: List[Dict[str, Any]]):
         def _get_comparator_args(condition, aggregated_data):
             if condition.comparator == MetricsComparator.RANGE:
-                return condition._comparator, aggregated_data, condition.value
+                return condition._comparator_raw, aggregated_data, condition.value
             return aggregated_data, condition.value
 
         for _query_data in response_data:

--- a/src/ychaos/testplan/verification/plugins/metrics.py
+++ b/src/ychaos/testplan/verification/plugins/metrics.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Dict, List, Tuple, Union, Optional
 
-from pydantic import Field, validate_arguments, validator
+from pydantic import Field, validate_arguments, validator, PrivateAttr
 
 from ....utils.builtins import AEnum, BuiltinUtils
 from ... import SchemaModel, SystemState
@@ -309,14 +309,14 @@ class ComparisonCondition(SchemaModel):
     value: Union[float, Tuple] = Field(
         ..., description="Numerical value/range to be used for comparison"
     )
-    comparator_raw: Optional[str] = Field(
+    _comparator_raw: Optional[str] = Field(
         default=None,
     )
 
     # Resolve Aliases
     @validator("comparator", pre=True)
     def resolve_comparator(cls, v, values):
-        values["comparator_raw"] = v  # Store the actual value in a private attribute
+        values["_comparator_raw"] = v  # Store the actual value in a private attribute
         return v
 
 

--- a/src/ychaos/testplan/verification/plugins/metrics.py
+++ b/src/ychaos/testplan/verification/plugins/metrics.py
@@ -5,9 +5,9 @@ import math
 import random
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Optional
 
-from pydantic import Field, validate_arguments, validator
+from pydantic import Field, validate_arguments, validator, PrivateAttr, Extra
 
 from ....utils.builtins import AEnum, BuiltinUtils
 from ... import SchemaModel, SystemState
@@ -301,7 +301,6 @@ class MetricsComparator(AEnum):
 
 
 class ComparisonCondition(SchemaModel):
-
     comparator: MetricsComparator = Field(
         ...,
         description="Comparison condition to compare between the metrics data and fetched value",
@@ -310,11 +309,12 @@ class ComparisonCondition(SchemaModel):
     value: Union[float, Tuple] = Field(
         ..., description="Numerical value/range to be used for comparison"
     )
+    comparator_raw: Optional[str] = Field(default=None, )
 
     # Resolve Aliases
     @validator("comparator", pre=True)
     def resolve_comparator(cls, v, values):
-        values["_comparator"] = v  # Store the actual value in a private attribute
+        values["comparator_raw"] = v  # Store the actual value in a private attribute
         return v
 
 

--- a/src/ychaos/testplan/verification/plugins/metrics.py
+++ b/src/ychaos/testplan/verification/plugins/metrics.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Dict, List, Tuple, Union, Optional
 
-from pydantic import Field, validate_arguments, validator, PrivateAttr, Extra
+from pydantic import Field, validate_arguments, validator
 
 from ....utils.builtins import AEnum, BuiltinUtils
 from ... import SchemaModel, SystemState
@@ -309,7 +309,9 @@ class ComparisonCondition(SchemaModel):
     value: Union[float, Tuple] = Field(
         ..., description="Numerical value/range to be used for comparison"
     )
-    comparator_raw: Optional[str] = Field(default=None, )
+    comparator_raw: Optional[str] = Field(
+        default=None,
+    )
 
     # Resolve Aliases
     @validator("comparator", pre=True)

--- a/src/ychaos/testplan/verification/plugins/metrics.py
+++ b/src/ychaos/testplan/verification/plugins/metrics.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Dict, List, Tuple, Union, Optional
 
-from pydantic import Field, validate_arguments, validator, PrivateAttr
+from pydantic import Field, validate_arguments, validator
 
 from ....utils.builtins import AEnum, BuiltinUtils
 from ... import SchemaModel, SystemState

--- a/tests/testplan/test_metrics.py
+++ b/tests/testplan/test_metrics.py
@@ -105,7 +105,7 @@ class TestStateBoundMetricsVerificationCriteria(TestCase):
             SystemState.STEADY
         )
         self.assertEqual(MetricsComparator.LE, comparator.comparator)
-        self.assertEqual("<=", comparator._comparator)
+        self.assertEqual("<=", comparator._comparator_raw)
         self.assertEqual(300, comparator.value)
 
     def test_metrics_when_no_criteria_is_defined(self):


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

The testplan formed when we run `ychaos execute` has the field _comparator which now throws an error cause extra fields are now forbidden.

---

<!-- 
    Link the issue number that this PR intends to fix. We highly
    recommend you to create an issue so that we can discuss on the approaches
    and all the possible solutions.
    
    Although, creating an issue is not mandatory and you are welcome to fix
    any issue!
-->

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [x] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [x] Reviewed Source Code
- [x] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
