### PR TITLE
Fix _comparator_raw throwing value_error.extra when running MachineTargetExecutor

### DIFF
--- a/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
+++ b/src/ychaos/core/verification/plugins/OpenTSDBVerificationPlugin.py
@@ -66,7 +66,7 @@ class OpenTSDBVerificationPlugin(RequestVerificationPlugin):
     def validate_criteria(self, response_data: List[Dict[str, Any]]):
         def _get_comparator_args(condition, aggregated_data):
             if condition.comparator == MetricsComparator.RANGE:
-                return condition._comparator_raw, aggregated_data, condition.value
+                return condition.comparator_raw, aggregated_data, condition.value
             return aggregated_data, condition.value
 
         for _query_data in response_data:

--- a/src/ychaos/testplan/verification/plugins/metrics.py
+++ b/src/ychaos/testplan/verification/plugins/metrics.py
@@ -309,14 +309,14 @@ class ComparisonCondition(SchemaModel):
     value: Union[float, Tuple] = Field(
         ..., description="Numerical value/range to be used for comparison"
     )
-    _comparator_raw: Optional[str] = Field(
+    comparator_raw: Optional[str] = Field(
         default=None,
     )
 
     # Resolve Aliases
     @validator("comparator", pre=True)
     def resolve_comparator(cls, v, values):
-        values["_comparator_raw"] = v  # Store the actual value in a private attribute
+        values["comparator_raw"] = v
         return v
 
 

--- a/src/ychaos/testplan/verification/plugins/metrics.py
+++ b/src/ychaos/testplan/verification/plugins/metrics.py
@@ -301,6 +301,7 @@ class MetricsComparator(AEnum):
 
 
 class ComparisonCondition(SchemaModel):
+
     comparator_raw: Optional[str] = Field(
         default=None,
     )

--- a/src/ychaos/testplan/verification/plugins/metrics.py
+++ b/src/ychaos/testplan/verification/plugins/metrics.py
@@ -301,6 +301,10 @@ class MetricsComparator(AEnum):
 
 
 class ComparisonCondition(SchemaModel):
+    comparator_raw: Optional[str] = Field(
+        default=None,
+    )
+
     comparator: MetricsComparator = Field(
         ...,
         description="Comparison condition to compare between the metrics data and fetched value",
@@ -308,9 +312,6 @@ class ComparisonCondition(SchemaModel):
 
     value: Union[float, Tuple] = Field(
         ..., description="Numerical value/range to be used for comparison"
-    )
-    comparator_raw: Optional[str] = Field(
-        default=None,
     )
 
     # Resolve Aliases

--- a/tests/testplan/test_metrics.py
+++ b/tests/testplan/test_metrics.py
@@ -105,7 +105,7 @@ class TestStateBoundMetricsVerificationCriteria(TestCase):
             SystemState.STEADY
         )
         self.assertEqual(MetricsComparator.LE, comparator.comparator)
-        self.assertEqual("<=", comparator._comparator_raw)
+        self.assertEqual("<=", comparator.comparator_raw)
         self.assertEqual(300, comparator.value)
 
     def test_metrics_when_no_criteria_is_defined(self):


### PR DESCRIPTION
# Summary
@yahoo/ychaos-dev
When running the MachineTargetExcutor, the testplan sent to the target host had the field _comparator_raw.
This was throwing value_error.extra as it was treated as an unmentioned field of the ComparisonCondition class (though it was added as a field #122). It seems to have to do with pydantics's handling of fields with  private variable names.

```bash
╭────────────────────────────────────────── Validation Error ──────────────────────────────────────────╮
│ 4 validation errors for TestPlan                                                                     │
│ verification -> 0 -> config -> criteria -> 0 -> conditionals -> 0 -> _comparator_raw                  │
│   extra fields not permitted (type=value_error.extra)                                                │
│ verification -> 0 -> config -> state_bound_criteria                                                  │
│   Either criteria or state_bound_criteria must be present for this configuration. (type=value_error) │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
 
With this PR I am fixing this by renaming _comparator_raw to a normal field 

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
