### PR TITLE
Supporting debug mode for Machine Target executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ docs/testplan/schema/*.css
 docs/testplan/schema/*.js
 docs/cli/manual.md
 
+*.DS_Store

--- a/src/ychaos/cli/execute.py
+++ b/src/ychaos/cli/execute.py
@@ -78,7 +78,9 @@ class Execute(YChaosTestplanInputSubCommand):
 
     def build_executor(self):
         if self.testplan.attack.target_type == TargetType.MACHINE:
-            self.executor = MachineTargetExecutor(testplan=self.testplan)
+            self.executor = MachineTargetExecutor(
+                testplan=self.testplan, is_debug_mode=self.app.is_debug_mode()
+            )
 
         elif self.testplan.attack.target_type == TargetType.SELF:
             self.executor = SelfTargetExecutor(testplan=self.testplan)

--- a/src/ychaos/core/executor/BaseExecutor.py
+++ b/src/ychaos/core/executor/BaseExecutor.py
@@ -24,10 +24,13 @@ class BaseExecutor(EventHook, ABC):
 
     __target_type__: str
 
-    def __init__(self, testplan: TestPlan, *args, **kwargs):
+    def __init__(
+        self, testplan: TestPlan, is_debug_mode: bool = False, *args, **kwargs
+    ):
         super(BaseExecutor, self).__init__()
         self.testplan = testplan
         self._validate_target_config()
+        self.debug_mode = is_debug_mode
 
     def _get_target_type(self):
         # To avoid circular import

--- a/src/ychaos/testplan/schema.py
+++ b/src/ychaos/testplan/schema.py
@@ -71,7 +71,8 @@ class TestPlan(TestPlanSchema):
     The Test Plan Dataclass.
     """
 
-    __test__ = False
+    __test__: bool = False
+    __src_path__: Path = Path()
 
     id: UUID = Field(
         default_factory=uuid4,
@@ -87,8 +88,8 @@ class TestPlan(TestPlanSchema):
 
     @classmethod
     def load_file(cls, path: Union[str, Path]) -> "TestPlan":
-        path = Path(path)
-        with open(path, "r") as file:
+        cls.__src_path__ = Path(path)
+        with open(cls.__src_path__, "r") as file:
             data = yaml.safe_load(file)
         return cls(**data)
 

--- a/tests/cli/test_execute.py
+++ b/tests/cli/test_execute.py
@@ -43,7 +43,7 @@ class TestVerificationCommand(TestCase):
     def test_execute_for_machine_target_when_no_targets_found(self):
         temp_testplan_file = NamedTemporaryFile("w+")
 
-        args = Namespace()
+        args = Namespace(debug=False)
         args.cls = self.cls
 
         # Create a Mocked CLI App

--- a/tests/core/executor/test_MachineTargetExecutor.py
+++ b/tests/core/executor/test_MachineTargetExecutor.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest import TestCase
 
 import yaml
-from mockito import ANY, mock, unstub, when, expect
+from mockito import ANY, mock, unstub, when, expect, verify
 
 from ychaos.core.exceptions.executor_errors import (
     YChaosTargetConfigConditionFailedError,
@@ -340,8 +340,9 @@ class TestMachineTargetExecutor(TestCase):
         executor.prepare()
         when(executor).prepare().thenReturn(None)
         expect(executor.ansible_context.tqm, times=1).run(ANY).thenReturn(None)
-        expect(os, times=1).remove(f"{ychaos_src_zip_path}.zip")
+        when(os).remove(f"{ychaos_src_zip_path}.zip").thenReturn(None)
         executor.execute()
+        verify(os, times=1).remove(f"{ychaos_src_zip_path}.zip")
 
     def tearDown(self) -> None:
         unstub()

--- a/tests/core/executor/test_MachineTargetExecutor.py
+++ b/tests/core/executor/test_MachineTargetExecutor.py
@@ -1,11 +1,13 @@
 #  Copyright 2021, Yahoo
 #  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
 import json
+import os
+import shutil
 from pathlib import Path
 from unittest import TestCase
 
 import yaml
-from mockito import ANY, mock, unstub, when
+from mockito import ANY, mock, unstub, when, expect
 
 from ychaos.core.exceptions.executor_errors import (
     YChaosTargetConfigConditionFailedError,
@@ -309,6 +311,37 @@ class TestMachineTargetExecutor(TestCase):
             map(lambda x: x["name"], executor.ansible_context.play_source["tasks"])
         )
         self.assertIn("Copy awesome_agent.py to remote", playbook_tasks)
+
+    def test_machine_executor_tasks_when_in_debug_mode(self):
+        mock_valid_testplan = TestPlan.load_file(
+            self.testplans_directory.joinpath("valid/testplan2.yaml")
+        )
+        ychaos_src_zip_path = f"{mock_valid_testplan.__src_path__.parent}/ychaos"
+        executor = MachineTargetExecutor(mock_valid_testplan, is_debug_mode=True)
+        expect(shutil, times=1).make_archive(
+            ychaos_src_zip_path, "zip", ANY
+        ).thenReturn(None)
+        executor.prepare()
+        playbook_tasks = list(
+            map(lambda x: x["name"], executor.ansible_context.play_source["tasks"])
+        )
+        self.assertIn("Get site-package parent directory", playbook_tasks)
+        self.assertIn("Unzip ychaos src at remote", playbook_tasks)
+
+    def test_ychaos_src_zip_is_removed_after_execution_in_debug_mode(self):
+        mock_valid_testplan = TestPlan.load_file(
+            self.testplans_directory.joinpath("valid/testplan2.yaml")
+        )
+        ychaos_src_zip_path = f"{mock_valid_testplan.__src_path__.parent}/ychaos"
+        executor = MachineTargetExecutor(mock_valid_testplan, is_debug_mode=True)
+        expect(shutil, times=1).make_archive(
+            ychaos_src_zip_path, "zip", ANY
+        ).thenReturn(None)
+        executor.prepare()
+        when(executor).prepare().thenReturn(None)
+        expect(executor.ansible_context.tqm, times=1).run(ANY).thenReturn(None)
+        expect(os, times=1).remove(f"{ychaos_src_zip_path}.zip")
+        executor.execute()
 
     def tearDown(self) -> None:
         unstub()


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

The cli implementation to take `--debug` as an option was already available.
With this PR, the debug implementation is added.
After ychaos is installed with pip on the remote host so all dependencies are met.
A Ychaos source dir is zipped to the test plans directory using `shutil` and unzipped at the remote host's virtual environment using ansible's built-in `unarchive` module.

The output of executing a testplan from running this branch 
```bash
[alfinst@remote ~]$ grep "Unzip" ychaos_env/lib/python3.8/site-packages/ychaos/core/executor/MachineTargetExecutor.py
                name="Unzip ychaos src at remote",
[alfinst@remote ~]$ ls
My_Docs  TempEnv  ychaos_env  ychaos_ws
[alfinst@remote ~]$ ls
My_Docs  TempEnv
```
We can see changes from this branch are available on remote!


---

**Fixes**: #8 

## Checklist

### Checklist (Developer)

#### Prerequisites
- [x] I have read the contribution guidelines

#### Code Analysis
- [x] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
