### PR TITLE
using full path for iptables command

### DIFF
--- a/src/ychaos/agents/network/iptables.py
+++ b/src/ychaos/agents/network/iptables.py
@@ -41,7 +41,7 @@ class IptablesRuleOperation(Enum):
 def iptables_command_builder(
     operation, chain, port, endpoint, iptable_wait_second
 ) -> str:
-    command = f"sudo iptables {shlex.quote(operation)} {shlex.quote(chain)}"
+    command = f"sudo /sbin/iptables {shlex.quote(operation)} {shlex.quote(chain)}"
 
     args = f" -p tcp -j DROP -w {shlex.quote(str(iptable_wait_second))}"
 
@@ -330,7 +330,7 @@ class DNSBlock(Agent):
     def run(self):
         super(DNSBlock, self).run()
 
-        _cmd = f"sudo iptables -I OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
+        _cmd = f"sudo /sbin/iptables -I OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
         proc = subprocess.run(  # nosec
             _cmd,
             stdout=subprocess.PIPE,
@@ -340,7 +340,7 @@ class DNSBlock(Agent):
             proc, "Error While Adding IPTables Rule: DROP udp port: 53 to OUTPUT chain"
         )
 
-        _cmd = f"sudo iptables -I OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
+        _cmd = f"sudo /sbin/iptables -I OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
         proc = subprocess.run(  # nosec
             _cmd,
             stdout=subprocess.PIPE,
@@ -360,7 +360,7 @@ class DNSBlock(Agent):
             AgentState.ERROR,
             AgentState.ABORTED,
         ):
-            _cmd = f"sudo iptables -D OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
+            _cmd = f"sudo /sbin/iptables -D OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
             proc = subprocess.run(  # nosec
                 _cmd,
                 stdout=subprocess.PIPE,
@@ -369,7 +369,7 @@ class DNSBlock(Agent):
 
             error = proc.returncode != 0 or error
 
-            _cmd = f"sudo iptables -D OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
+            _cmd = f"sudo /sbin/iptables -D OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
             proc = subprocess.run(  # nosec
                 _cmd,
                 stdout=subprocess.PIPE,

--- a/src/ychaos/agents/network/iptables.py
+++ b/src/ychaos/agents/network/iptables.py
@@ -39,9 +39,7 @@ class IptablesRuleOperation(Enum):
     DELETE = "-D"
 
 
-iptables_command = shutil.which("iptables")
-if iptables_command is None:
-    iptables_command = "/sbin/iptables"
+iptables_command = shutil.which("iptables") or "/sbin/iptables"
 
 
 def iptables_command_builder(

--- a/src/ychaos/agents/network/iptables.py
+++ b/src/ychaos/agents/network/iptables.py
@@ -2,6 +2,7 @@
 #  Licensed under the terms of the Apache 2.0 license. See the LICENSE file in the project root for terms
 
 import shlex
+import shutil
 import subprocess  # nosec using shlex
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Network
@@ -38,10 +39,15 @@ class IptablesRuleOperation(Enum):
     DELETE = "-D"
 
 
+iptables_command = shutil.which("iptables")
+if iptables_command is None:
+    iptables_command = "/sbin/iptables"
+
+
 def iptables_command_builder(
     operation, chain, port, endpoint, iptable_wait_second
 ) -> str:
-    command = f"sudo /sbin/iptables {shlex.quote(operation)} {shlex.quote(chain)}"
+    command = f"sudo {iptables_command} {shlex.quote(operation)} {shlex.quote(chain)}"
 
     args = f" -p tcp -j DROP -w {shlex.quote(str(iptable_wait_second))}"
 
@@ -330,7 +336,7 @@ class DNSBlock(Agent):
     def run(self):
         super(DNSBlock, self).run()
 
-        _cmd = f"sudo /sbin/iptables -I OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
+        _cmd = f"sudo {iptables_command} -I OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
         proc = subprocess.run(  # nosec
             _cmd,
             stdout=subprocess.PIPE,
@@ -340,7 +346,7 @@ class DNSBlock(Agent):
             proc, "Error While Adding IPTables Rule: DROP udp port: 53 to OUTPUT chain"
         )
 
-        _cmd = f"sudo /sbin/iptables -I OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
+        _cmd = f"sudo {iptables_command} -I OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {shlex.quote(str(self.config.iptables_wait))}".split()
         proc = subprocess.run(  # nosec
             _cmd,
             stdout=subprocess.PIPE,
@@ -360,7 +366,7 @@ class DNSBlock(Agent):
             AgentState.ERROR,
             AgentState.ABORTED,
         ):
-            _cmd = f"sudo /sbin/iptables -D OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
+            _cmd = f"sudo {iptables_command} -D OUTPUT -p udp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
             proc = subprocess.run(  # nosec
                 _cmd,
                 stdout=subprocess.PIPE,
@@ -369,7 +375,7 @@ class DNSBlock(Agent):
 
             error = proc.returncode != 0 or error
 
-            _cmd = f"sudo /sbin/iptables -D OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
+            _cmd = f"sudo {iptables_command} -D OUTPUT -p tcp --dport {self.DNS_PORT} -j DROP -w {self.config.iptables_wait}".split()
             proc = subprocess.run(  # nosec
                 _cmd,
                 stdout=subprocess.PIPE,

--- a/tests/agents/network/test_BlockDNS.py
+++ b/tests/agents/network/test_BlockDNS.py
@@ -51,13 +51,13 @@ class TestBlockDNSConfig(TestCase):
         when(os).geteuid().thenReturn(0)
 
         when(subprocess).run(
-            "sudo iptables -I OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
+            "sudo /sbin/iptables -I OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=0))
 
         when(subprocess).run(
-            f"sudo iptables -I OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
+            f"sudo /sbin/iptables -I OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=0))
@@ -76,13 +76,13 @@ class TestBlockDNSConfig(TestCase):
         when(os).geteuid().thenReturn(0)
 
         when(subprocess).run(
-            "sudo iptables -I OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
+            "sudo /sbin/iptables -I OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=0))
 
         when(subprocess).run(
-            f"sudo iptables -I OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
+            f"sudo /sbin/iptables -I OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=1))
@@ -100,13 +100,13 @@ class TestBlockDNSConfig(TestCase):
         agent.advance_state(AgentState.RUNNING)
 
         when(subprocess).run(
-            "sudo iptables -D OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
+            "sudo /sbin/iptables -D OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=0))
 
         when(subprocess).run(
-            "sudo iptables -D OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
+            "sudo /sbin/iptables -D OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=0))
@@ -129,13 +129,13 @@ class TestBlockDNSConfig(TestCase):
         agent.advance_state(AgentState.RUNNING)
 
         when(subprocess).run(
-            "sudo iptables -D OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
+            "sudo /sbin/iptables -D OUTPUT -p udp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=0))
 
         when(subprocess).run(
-            "sudo iptables -D OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
+            "sudo /sbin/iptables -D OUTPUT -p tcp --dport 53 -j DROP -w 3".split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ).thenReturn(subprocess.CompletedProcess(args=[], returncode=1))

--- a/tests/agents/network/test_iptables.py
+++ b/tests/agents/network/test_iptables.py
@@ -54,28 +54,28 @@ class TestIPTablesBlock(TestCase):
         self.mock_subprocess_exits_normally(ANY)
         agent.run()
         self.verify_sub_process(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
         )
         self.verify_sub_process(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
         )
         self.verify_sub_process(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
         )
         self.verify_sub_process(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
         )
         self.verify_sub_process(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         self.verify_sub_process(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
         )
         self.verify_sub_process(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         self.verify_sub_process(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
         )
 
     def test_run_sets_ip_tables_rules_incoming_port_error(self):
@@ -83,10 +83,10 @@ class TestIPTablesBlock(TestCase):
         iptables_block_agent_config = self.iptables_block_agent_config
         agent = IPTablesBlock(iptables_block_agent_config)
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
         )
         self.mock_subprocess_exits_with_error(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
         )
         agent.setup()
         with self.assertRaises(IOError):
@@ -97,16 +97,16 @@ class TestIPTablesBlock(TestCase):
         iptables_block_agent_config = self.iptables_block_agent_config
         agent = IPTablesBlock(iptables_block_agent_config)
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
         )
         self.mock_subprocess_exits_with_error(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
         )
         agent.setup()
         with self.assertRaises(IOError):
@@ -117,19 +117,19 @@ class TestIPTablesBlock(TestCase):
         iptables_block_agent_config = self.iptables_block_agent_config
         agent = IPTablesBlock(iptables_block_agent_config)
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
         )
         self.mock_subprocess_exits_with_error(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         agent.setup()
         with self.assertRaises(IOError):
@@ -140,22 +140,22 @@ class TestIPTablesBlock(TestCase):
         iptables_block_agent_config = self.iptables_block_agent_config
         agent = IPTablesBlock(iptables_block_agent_config)
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         self.mock_subprocess_exits_with_error(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
         )
         agent.setup()
         with self.assertRaises(IOError):
@@ -166,25 +166,25 @@ class TestIPTablesBlock(TestCase):
         iptables_block_agent_config = self.iptables_block_agent_config
         agent = IPTablesBlock(iptables_block_agent_config)
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
         )
         self.mock_subprocess_exits_with_error(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         agent.setup()
         with self.assertRaises(IOError):
@@ -195,28 +195,28 @@ class TestIPTablesBlock(TestCase):
         iptables_block_agent_config = self.iptables_block_agent_config
         agent = IPTablesBlock(iptables_block_agent_config)
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9000"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 9001"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9002"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 9003"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
+            "sudo /sbin/iptables -I INPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
         )
         self.mock_subprocess_exits_normally(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 -d 203.0.113.0/32"
         )
         self.mock_subprocess_exits_with_error(
-            "sudo iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
+            "sudo /sbin/iptables -I OUTPUT -p tcp -j DROP -w 1 --dport 443 -d yahoo.com"
         )
         agent.setup()
         with self.assertRaises(IOError):


### PR DESCRIPTION
# Summary

@yahoo/ychaos-dev

  There was a case where the iptables agent failed cause of PATH variable issues when we ssh to host from screwdriver piepeline.
Using the full path so this issue can be resolved.

---

## Checklist

### Checklist (Developer)

#### Prerequisites
- [ ] I have read the contribution guidelines

#### Code Analysis
- [ ] Covered by Unittests
- [ ] Security warnings ignored (Why?!)

#### Project related
- [ ] Schema changed and is backward compatible.
- [ ] Introduces a new sub-command for ychaos CLI

### Autogenerated Files
- [ ] Auto generated schema

### Pre-Merge Checklist

- [ ] All the build jobs are passing

---

### Checklist (Reviewer 1)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)

### Checklist (Reviewer 2)

- [ ] Reviewed Source Code
- [ ] Reviewed Tests (If applicable)
- [ ] Reviewed Documentation (If applicable)
